### PR TITLE
Fixed 'Flutter Coverage' extension compatibility

### DIFF
--- a/lib/combine_coverage.dart
+++ b/lib/combine_coverage.dart
@@ -27,8 +27,6 @@ void combineCoverage(String repoPath, String outputDirectory) async {
       .replaceAll(absoluteRepoPath, '')
       .replaceAll('SF:.', 'SF:');
 
-  print(absoluteRepoPath);
-
   await combinedCoverageFile.write(content).then((_) {
     stdout.writeln('Coverage info combined successfully!');
     stdout.writeln('See combined file @ ${combinedCoverageFile.path}');


### PR DESCRIPTION
The 'Flutter Coverage' extension wasn't compatible with the coverage files being output previously.  This merge aims to fix that, along with issues caused by using './' as the repo directory argument.